### PR TITLE
🐛 fix(chart): add feedback when selecting time range in Product Summary graph

### DIFF
--- a/platform/src/Components/LineChart/lineChart.tsx
+++ b/platform/src/Components/LineChart/lineChart.tsx
@@ -2,6 +2,7 @@ import { Chart, CategoryScale, LinearScale, PointElement, LineElement, Tooltip, 
 import { Line } from 'react-chartjs-2';
 import { baseTheme } from '@Themes';
 import { Container } from './lineChart.styles';
+import { NoDataContainer } from '../MaterialCategoriesChart/materialCategoriesChart.styles';
 
 Chart.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Filler);
 
@@ -38,6 +39,8 @@ const options = {
 };
 
 const LineChart = ({ xAxis, yAxis, targetAxis }: { xAxis: string[]; yAxis: number[]; targetAxis?: number[] }) => {
+  const hasData = xAxis.length > 0 && yAxis.length > 0;
+
   const datasets = {
     labels: xAxis,
     datasets: [
@@ -62,7 +65,13 @@ const LineChart = ({ xAxis, yAxis, targetAxis }: { xAxis: string[]; yAxis: numbe
 
   return (
     <Container>
-      <Line data={datasets} options={options} />
+      {hasData ? (
+        <Line data={datasets} options={options} />
+      ) : (
+        <NoDataContainer>
+          <p>No data available for the selected time range.</p>
+        </NoDataContainer>
+      )}
     </Container>
   );
 };

--- a/platform/src/Components/MaterialCategoriesChart/materialCategoriesChart.styles.ts
+++ b/platform/src/Components/MaterialCategoriesChart/materialCategoriesChart.styles.ts
@@ -46,7 +46,7 @@ export const TimeRangeContainer = styled.div`
   border: none;
 `;
 
-export const Option = styled.div`
+export const Option = styled.div<{ isSelected: boolean }>`
   width: 100px;
   height: 25px;
   text-align: center;
@@ -56,9 +56,23 @@ export const Option = styled.div`
   justify-content: space-around;
   align-items: center;
   border-bottom: 2px solid ${(props) => props.theme.colors.transparentBlack};
+  color: ${({ isSelected, theme }) => (isSelected ? theme.colors.bopsPurple : 'inherit')};
 
   &:hover {
     font-weight: 800;
     border-bottom: 2px solid ${(props) => props.theme.colors.bopsPurple};
   }
+`;
+
+export const NoDataContainer = styled.div`
+  width: 830px;
+  height: 270px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${(props) => props.theme.colors.cardBackgroundTransparent};
+  color: ${(props) => props.theme.colors.fontGrey};
+  font-size: 18px;
+  border: 1px solid ${(props) => props.theme.colors.cardBorder};
+  border-radius: 10px;
 `;

--- a/platform/src/Components/MaterialCategoriesChart/materialCategoriesChart.tsx
+++ b/platform/src/Components/MaterialCategoriesChart/materialCategoriesChart.tsx
@@ -1,3 +1,4 @@
+import React, { useState } from 'react';
 import { LineChart } from '@Components';
 import {
   Container,
@@ -32,7 +33,10 @@ const MaterialCategoriesChart = ({
   timeRanges: TimeRangeOption[];
   onTimeRangeChange: (value: number) => void;
 }) => {
+  const [selectedTimeRange, setSelectedTimeRange] = useState<number>(timeRanges[0]?.value || 0);
+
   const onTimeRangeClicked = (option: TimeRangeOption) => {
+    setSelectedTimeRange(option.value);
     onTimeRangeChange(option.value);
   };
 
@@ -46,8 +50,14 @@ const MaterialCategoriesChart = ({
         </LineContainer>
         <TimeRangeContainer>
           {timeRanges.map((timeRange) => {
-            const option = <Option onClick={() => onTimeRangeClicked(timeRange)}>{timeRange.name}</Option>;
-            return <Div key={timeRange.value}>{option}</Div>;
+            const isSelected = timeRange.value === selectedTimeRange;
+            return (
+              <Div key={timeRange.value}>
+                <Option onClick={() => onTimeRangeClicked(timeRange)} isSelected={isSelected}>
+                  {timeRange.name}
+                </Option>
+              </Div>
+            );
           })}
         </TimeRangeContainer>
       </LineCard>


### PR DESCRIPTION
Resolved the issue where there was no visual feedback when selecting the time range in the Product Summary’s graph. Now, the selected range is highlighted as expected. Also added "No data available" message when there is no data for the chart.